### PR TITLE
Reject twitter.com/search as a profile, and allow mobile.twitter.com profiles

### DIFF
--- a/lib/is.js
+++ b/lib/is.js
@@ -19,7 +19,15 @@ var util = require('./util');
     });
     def({
         fn: 'twitter.profile',
-        re: url('twitter\\.com\\/' + handle)
+        re: url('(mobile\\.)?twitter\\.com\\/' + handle),
+        after: function(data) {
+          // avoid special twitter urls that aren't profiles
+          if(data.endsWith('/search')) {
+            return false;
+          }
+
+          return true;
+        }
     });
 })();
 

--- a/test/is.test.js
+++ b/test/is.test.js
@@ -10,7 +10,6 @@ describe('`is`', function () {
             checkThat: undefined,
             is: false
         },
-
         'checks valid twitter handle without @ sign': {
             fn: 'twitter.handle',
             checkThat: 'ConnorPeet',
@@ -48,6 +47,22 @@ describe('`is`', function () {
             fn: 'twitter.handle',
             checkThat: 'ConnorPeet',
             using: { at: true },
+            is: false
+        },
+        'rejects twitter search url as handle': {
+            fn: 'twitter.handle',
+            checkThat: 'https://twitter.com/search',
+            using: { at: false },
+            is: false
+        },
+        'accepts mobile twitter url as profile': {
+            fn: 'twitter.profile',
+            checkThat: 'https://mobile.twitter.com/ConnorPeet',
+            is: true
+        },
+        'rejects twitter search url as profile': {
+            fn: 'twitter.profile',
+            checkThat: 'https://twitter.com/search',
             is: false
         },
         'checks valid facebook name': {


### PR DESCRIPTION
Closes #4 

Looks like a useful project! I noticed that it doesn't think `mobile.twitter.com` profiles are a profile, so I modified the regex while I was in here.